### PR TITLE
ZKX-1731 add batch id to the events

### DIFF
--- a/L2/contracts/AccountManager.cairo
+++ b/L2/contracts/AccountManager.cairo
@@ -1174,7 +1174,7 @@ func execute_order{
         assert data[9] = opening_fee;
         assert data[10] = is_final;
 
-        emit_event(1, keys, 11, data);
+        emit_event(2, keys, 11, data);
 
         return (1,);
     }

--- a/L2/contracts/AccountManager.cairo
+++ b/L2/contracts/AccountManager.cairo
@@ -1057,6 +1057,7 @@ func transfer_abr{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_pt
 }
 
 // @notice Function called by Trading Contract
+// @param batch_id - ID of the batch
 // @param request - Details of the order to be executed
 // @param signature - Details of the signature
 // @param size - Size of the Order to be executed
@@ -1072,6 +1073,7 @@ func transfer_abr{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_pt
 func execute_order{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, ecdsa_ptr: SignatureBuiltin*
 }(
+    batch_id: felt,
     request: OrderRequest,
     signature: Signature,
     size: felt,
@@ -1158,6 +1160,7 @@ func execute_order{
         // Emit event for the order
         let (keys: felt*) = alloc();
         assert keys[0] = 'trade';
+        assert keys[1] = batch_id;
         let (data: felt*) = alloc();
         assert data[0] = order_id;
         assert data[1] = market_id;

--- a/L2/contracts/Trading.cairo
+++ b/L2/contracts/Trading.cairo
@@ -200,6 +200,7 @@ func execute_batch{
 
     // Recursively loop through the orders in the batch
     let (taker_execution_price: felt, open_interest: felt) = check_and_execute(
+        batch_id_=batch_id_,
         market_id_=market_id_,
         collateral_id_=collateral_id,
         asset_token_decimal_=asset.token_decimal,
@@ -1151,6 +1152,7 @@ func process_close_orders{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_
 }
 
 // @notice Internal function called by execute_batch
+// @param batch_id_ - ID of the batch
 // @param market_id_ - Market ID of the batch
 // @param collateralID_ - Collateral ID of the batch to be set by the first order
 // @param asset_token_decimal_ - No.of token decimals of an asset
@@ -1180,6 +1182,7 @@ func process_close_orders{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_
 // @return trader_stats_list_len - length of the trader fee list so far
 // @return open_interest - open interest corresponding to the trade batch
 func check_and_execute{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    batch_id_: felt,
     market_id_: felt,
     collateral_id_: felt,
     asset_token_decimal_: felt,
@@ -1350,6 +1353,7 @@ func check_and_execute{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_che
         let (keys: felt*) = alloc();
         assert keys[0] = 'trade_execution';
         assert keys[1] = market_id_;
+        assert keys[2] = batch_id_;
         let (data: felt*) = alloc();
         assert data[0] = quantity_to_execute;
         assert data[1] = execution_price;
@@ -1404,6 +1408,7 @@ func check_and_execute{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_che
             // Call the account contract to initialize the order
             IAccountManager.execute_order(
                 contract_address=user_address,
+                batch_id=batch_id_,
                 request=temp_order_request,
                 signature=temp_signature,
                 size=0,
@@ -1431,6 +1436,7 @@ func check_and_execute{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_che
             assert [trader_stats_list_] = element;
 
             return check_and_execute(
+                batch_id_=batch_id_,
                 market_id_=market_id_,
                 collateral_id_=collateral_id_,
                 asset_token_decimal_=asset_token_decimal_,
@@ -1573,6 +1579,7 @@ func check_and_execute{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_che
     // Call the account contract to initialize the order
     IAccountManager.execute_order(
         contract_address=user_address,
+        batch_id=batch_id_,
         request=temp_order_request,
         signature=temp_signature,
         size=quantity_to_execute,
@@ -1591,6 +1598,7 @@ func check_and_execute{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_che
     let (new_open_interest) = Math64x61_add(open_interest_, current_open_interest);
 
     return check_and_execute(
+        batch_id_=batch_id_,
         market_id_=market_id_,
         collateral_id_=collateral_id_,
         asset_token_decimal_=asset_token_decimal_,

--- a/L2/contracts/Trading.cairo
+++ b/L2/contracts/Trading.cairo
@@ -145,6 +145,11 @@ func execute_batch{
 ) -> () {
     alloc_locals;
 
+    let (status: felt) = batch_id_status.read(batch_id=batch_id_);
+    with_attr error_message("0525: {batch_id_}") {
+        assert status = FALSE;
+    }
+
     // Get all the addresses from the auth registry
     let (
         account_registry_address: felt,

--- a/L2/contracts/Trading.cairo
+++ b/L2/contracts/Trading.cairo
@@ -1365,7 +1365,7 @@ func check_and_execute{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_che
         assert data[2] = [request_list_].direction;
         assert data[3] = [request_list_].side;
 
-        emit_event(2, keys, 4, data);
+        emit_event(3, keys, 4, data);
 
         tempvar syscall_ptr = syscall_ptr;
         tempvar pedersen_ptr = pedersen_ptr;

--- a/L2/contracts/interfaces/IAccountManager.cairo
+++ b/L2/contracts/interfaces/IAccountManager.cairo
@@ -70,6 +70,7 @@ namespace IAccountManager {
     // External functions
 
     func execute_order(
+        batch_id: felt,
         request: OrderRequest,
         signature: Signature,
         size: felt,

--- a/L2/tests/test_RelayTrading.py
+++ b/L2/tests/test_RelayTrading.py
@@ -1800,6 +1800,8 @@ async def test_placing_order_directly(trading_test_initializer):
 
     # Create orders
     params = [
+        # batch id
+        1, 
         # order_id
         36913743897347031862778619449,
         # market_id

--- a/L2/tests/test_RelayTrading.py
+++ b/L2/tests/test_RelayTrading.py
@@ -465,7 +465,7 @@ async def test_for_risk_while_opening_order(trading_test_initializer):
     assert_event_with_custom_keys_emitted(
         tx_exec_info=info,
         from_address=trading.contract_address,
-        keys=[str_to_felt('trade_execution'), market_id_1],
+        keys=[str_to_felt('trade_execution'), market_id_1, batch_id_1],
         data=[to64x61(quantity_locked_1), to64x61(
             200), order_direction["short"], side["buy"]],
         order=6
@@ -1429,7 +1429,7 @@ async def test_opening_and_closing_full_orders(trading_test_initializer):
     assert_event_with_custom_keys_emitted(
         tx_exec_info=info,
         from_address=trading.contract_address,
-        keys=[str_to_felt('trade_execution'), market_id_1],
+        keys=[str_to_felt('trade_execution'), market_id_1, batch_id_1],
         data=[to64x61(quantity_locked_1), to64x61(
             1000), order_direction["short"], side["buy"]],
         order=5
@@ -1647,11 +1647,11 @@ async def test_closing_partial_orders(trading_test_initializer):
     }]
 
     # execute order
-    (_, complete_orders_1, info) = await execute_and_compare(zkx_node_signer=admin1_signer, zkx_node=admin1, executor=python_executor, orders=orders_2, users_test=users_test, quantity_locked=quantity_locked_2, market_id=market_id_1, oracle_price=oracle_price_2, trading=trading, timestamp=timestamp1, is_reverted=0, error_code=0)
+    (batch_id_1, complete_orders_1, info) = await execute_and_compare(zkx_node_signer=admin1_signer, zkx_node=admin1, executor=python_executor, orders=orders_2, users_test=users_test, quantity_locked=quantity_locked_2, market_id=market_id_1, oracle_price=oracle_price_2, trading=trading, timestamp=timestamp1, is_reverted=0, error_code=0)
     assert_event_with_custom_keys_emitted(
         tx_exec_info=info,
         from_address=trading.contract_address,
-        keys=[str_to_felt('trade_execution'), market_id_1],
+        keys=[str_to_felt('trade_execution'), market_id_1, batch_id_1],
         data=[to64x61(quantity_locked_2), to64x61(
             1000), order_direction["long"], side["buy"]],
         order=3

--- a/L2/tests/test_Trading.py
+++ b/L2/tests/test_Trading.py
@@ -427,7 +427,7 @@ async def test_for_risk_while_opening_order(trading_test_initializer):
     assert_event_with_custom_keys_emitted(
         tx_exec_info=info,
         from_address=trading.contract_address,
-        keys=[str_to_felt('trade_execution'), market_id_1],
+        keys=[str_to_felt('trade_execution'), market_id_1, batch_id_1],
         data=[to64x61(quantity_locked_1), to64x61(
             200), order_direction["short"], side["buy"]],
         order=6
@@ -1391,7 +1391,7 @@ async def test_opening_and_closing_full_orders(trading_test_initializer):
     assert_event_with_custom_keys_emitted(
         tx_exec_info=info,
         from_address=trading.contract_address,
-        keys=[str_to_felt('trade_execution'), market_id_1],
+        keys=[str_to_felt('trade_execution'), market_id_1, batch_id_1],
         data=[to64x61(quantity_locked_1), to64x61(
             1000), order_direction["short"], side["buy"]],
         order=5
@@ -1609,11 +1609,11 @@ async def test_closing_partial_orders(trading_test_initializer):
     }]
 
     # execute order
-    (_, complete_orders_1, info) = await execute_and_compare(zkx_node_signer=admin1_signer, zkx_node=admin1, executor=python_executor, orders=orders_2, users_test=users_test, quantity_locked=quantity_locked_2, market_id=market_id_1, oracle_price=oracle_price_2, trading=trading, timestamp=timestamp1, is_reverted=0, error_code=0)
+    (batch_id_1, complete_orders_1, info) = await execute_and_compare(zkx_node_signer=admin1_signer, zkx_node=admin1, executor=python_executor, orders=orders_2, users_test=users_test, quantity_locked=quantity_locked_2, market_id=market_id_1, oracle_price=oracle_price_2, trading=trading, timestamp=timestamp1, is_reverted=0, error_code=0)
     assert_event_with_custom_keys_emitted(
         tx_exec_info=info,
         from_address=trading.contract_address,
-        keys=[str_to_felt('trade_execution'), market_id_1],
+        keys=[str_to_felt('trade_execution'), market_id_1, batch_id_1],
         data=[to64x61(quantity_locked_2), to64x61(
             1000), order_direction["long"], side["buy"]],
         order=3

--- a/L2/tests/test_Trading.py
+++ b/L2/tests/test_Trading.py
@@ -1762,6 +1762,8 @@ async def test_placing_order_directly(trading_test_initializer):
 
     # Create orders
     params = [
+        # batch id
+        1, 
         # order_id
         36913743897347031862778619449,
         # market_id

--- a/L2/tests/test_Trading_0_fee.py
+++ b/L2/tests/test_Trading_0_fee.py
@@ -406,7 +406,7 @@ async def test_for_risk_while_opening_order(trading_test_initializer):
     assert_event_with_custom_keys_emitted(
         tx_exec_info=info,
         from_address=trading.contract_address,
-        keys=[str_to_felt('trade_execution'), market_id_1],
+        keys=[str_to_felt('trade_execution'), market_id_1, batch_id_1],
         data=[to64x61(quantity_locked_1), to64x61(
             200), order_direction["short"], side["buy"]],
         order=4
@@ -1358,7 +1358,7 @@ async def test_opening_and_closing_full_orders(trading_test_initializer):
     assert_event_with_custom_keys_emitted(
         tx_exec_info=info,
         from_address=trading.contract_address,
-        keys=[str_to_felt('trade_execution'), market_id_1],
+        keys=[str_to_felt('trade_execution'), market_id_1, batch_id_1],
         data=[to64x61(quantity_locked_1), to64x61(
             1000), order_direction["short"], side["buy"]],
         order=3
@@ -1557,11 +1557,11 @@ async def test_closing_partial_orders(trading_test_initializer):
     }]
 
     # execute order
-    (_, complete_orders_1, info) = await execute_and_compare(zkx_node_signer=admin1_signer, zkx_node=admin1, executor=python_executor, orders=orders_2, users_test=users_test, quantity_locked=quantity_locked_2, market_id=market_id_1, oracle_price=oracle_price_2, trading=trading, timestamp=timestamp1, is_reverted=0, error_code=0)
+    (batch_id_1, complete_orders_1, info) = await execute_and_compare(zkx_node_signer=admin1_signer, zkx_node=admin1, executor=python_executor, orders=orders_2, users_test=users_test, quantity_locked=quantity_locked_2, market_id=market_id_1, oracle_price=oracle_price_2, trading=trading, timestamp=timestamp1, is_reverted=0, error_code=0)
     assert_event_with_custom_keys_emitted(
         tx_exec_info=info,
         from_address=trading.contract_address,
-        keys=[str_to_felt('trade_execution'), market_id_1],
+        keys=[str_to_felt('trade_execution'), market_id_1, batch_id_1],
         data=[to64x61(quantity_locked_2), to64x61(
             1000), order_direction["long"], side["buy"]],
         order=3
@@ -1699,6 +1699,8 @@ async def test_placing_order_directly(trading_test_initializer):
 
     # Create orders
     params = [
+        # batch id
+        1, 
         # order_id
         36913743897347031862778619449,
         # market_id


### PR DESCRIPTION
This PR addresses the following:
1. Outputs an error with specific code In execute_batch, if already processed batchId is passed.
2. Adds key named batchId in AccountManager.trade and Trading.trade_execution events.
3. Fixes failed tests