### PR TITLE
Zkx 1820 prevent orders with massive losses from being opened in the system

### DIFF
--- a/L2/contracts/Trading.cairo
+++ b/L2/contracts/Trading.cairo
@@ -660,6 +660,7 @@ func get_registry_addresses{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, rang
 func process_open_orders{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     order_: MultipleOrder,
     execution_price_: felt,
+    oracle_price_: felt,
     order_size_: felt,
     market_id_: felt,
     collateral_id_: felt,
@@ -738,7 +739,9 @@ func process_open_orders{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_c
         order_=order_,
         size=order_size_,
         execution_price_=execution_price_,
+        oracle_price_=oracle_price_,
         margin_amount_=margin_order_value,
+        collateral_token_decimal_=collateral_token_decimal_,
     );
 
     // Setting local values to be used in error message
@@ -2315,6 +2318,7 @@ func process_and_execute_orders_recurse{
         ) = process_open_orders(
             order_=[request_list_],
             execution_price_=execution_price,
+            oracle_price_=oracle_price_,
             order_size_=quantity_to_execute,
             market_id_=market_id_,
             collateral_id_=collateral_id_,

--- a/L2/contracts/interfaces/ILiquidate.cairo
+++ b/L2/contracts/interfaces/ILiquidate.cairo
@@ -15,7 +15,12 @@ namespace ILiquidate {
     // External functions
 
     func check_for_risk(
-        order_: MultipleOrder, size: felt, execution_price_: felt, margin_amount_: felt
+        order_: MultipleOrder,
+        size: felt,
+        execution_price_: felt,
+        oracle_price_: felt,
+        margin_amount_: felt,
+        collateral_token_decimal_: felt,
     ) -> (available_margin: felt, is_liquidation: felt) {
     }
 

--- a/L2/contracts/relay_contracts/RelayLiquidate.cairo
+++ b/L2/contracts/relay_contracts/RelayLiquidate.cairo
@@ -5,7 +5,7 @@ from contracts.libraries.RelayLibrary import (
     get_inner_contract,
     initialize,
     record_call_details,
-    get_call_counter
+    get_call_counter,
 )
 
 from contracts.DataTypes import PositionDetailsForRiskManagement, MultipleOrder
@@ -52,7 +52,12 @@ func return_acc_value{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_chec
 
 @external
 func check_for_risk{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    order_: MultipleOrder, size_: felt, execution_price_: felt, margin_amount_: felt
+    order_: MultipleOrder,
+    size_: felt,
+    execution_price_: felt,
+    oracle_price_: felt,
+    margin_amount_: felt,
+    collateral_token_decimal_: felt,
 ) -> () {
     alloc_locals;
 
@@ -61,7 +66,15 @@ func check_for_risk{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_
 
     record_call_details('check_for_risk');
     let (inner_address) = get_inner_contract();
-    ILiquidate.check_for_risk(inner_address, order_, size_, execution_price_, margin_amount_);
+    ILiquidate.check_for_risk(
+        inner_address,
+        order_,
+        size_,
+        execution_price_,
+        oracle_price_,
+        margin_amount_,
+        collateral_token_decimal_,
+    );
     return ();
 }
 
@@ -73,7 +86,7 @@ func mark_under_collateralized_position{
     least_collateral_ratio_position: PositionDetailsForRiskManagement,
     total_account_value: felt,
     total_maintenance_requirement: felt,
-){
+) {
     alloc_locals;
 
     local pedersen_ptr: HashBuiltin* = pedersen_ptr;
@@ -86,7 +99,11 @@ func mark_under_collateralized_position{
         least_collateral_ratio_position: PositionDetailsForRiskManagement,
         total_account_value: felt,
         total_maintenance_requirement: felt,
-    ) = ILiquidate.mark_under_collateralized_position(contract_address = inner_address, account_address_=account_address_, collateral_id_=collateral_id_);
+    ) = ILiquidate.mark_under_collateralized_position(
+        contract_address=inner_address,
+        account_address_=account_address_,
+        collateral_id_=collateral_id_,
+    );
     return (
         liq_result,
         least_collateral_ratio_position,

--- a/L2/tests/test_RelayTrading.py
+++ b/L2/tests/test_RelayTrading.py
@@ -456,6 +456,49 @@ async def test_set_balance_by_non_admin(trading_test_initializer):
 
 
 @pytest.mark.asyncio
+async def test_for_extremely_low_price_revert(trading_test_initializer):
+    starknet_service, python_executor, admin1, _, _, _, _, _, _, felix, gary, _, _, _, _, felix_test, gary_test, _, _, _, trading, marketPrices, _, holding, fee_balance, liquidity, insurance, trading_stats, _, _, _, _, _ = trading_test_initializer
+
+    ###################
+    ### Open orders ##
+    ###################
+    # List of users
+    users = [felix, gary]
+    users_test = [felix_test, gary_test]
+
+    # Sufficient balance for users
+    felix_balance = 10000
+    gary_balance = 10000
+    balance_array = [felix_balance, gary_balance]
+
+    # Batch params for OPEN orders
+    quantity_locked_1 = 10000
+    market_id_1 = BTC_USD_ID
+    asset_id_1 = AssetID.USDC
+    oracle_price_1 = 1950
+
+    # Set balance in Starknet & Python
+    await set_balance(admin_signer=admin1_signer, admin=admin1, users=users, users_test=users_test, balance_array=balance_array, asset_id=asset_id_1)
+
+    # Create orders
+    orders_1 = [{
+        "quantity": 10000,
+        "price": 1,
+        "order_type": order_types["limit"],
+        "leverage": 10
+    }, {
+        "quantity": 10000,
+        "price": 1,
+        "direction": order_direction["short"],
+        "order_type": order_types["limit"],
+        "leverage": 10
+    }]
+
+    # execute order
+    await execute_and_compare(zkx_node_signer=admin1_signer, zkx_node=admin1, executor=python_executor, orders=orders_1, users_test=users_test, quantity_locked=quantity_locked_1, market_id=market_id_1, oracle_price=oracle_price_1, trading=trading, is_reverted=1, error_code="531:", error_at_index=1, timestamp=timestamp, param_2=market_id_1)
+
+
+@pytest.mark.asyncio
 async def test_for_risk_while_opening_order(trading_test_initializer):
     starknet_service, python_executor, admin1, _, _, _, _, _, _, felix, gary, _, _, _, _, felix_test, gary_test, _, _, _, trading, marketPrices, _, holding, fee_balance, liquidity, insurance, trading_stats, _, _, _, _, _ = trading_test_initializer
 

--- a/L2/tests/test_Trading.py
+++ b/L2/tests/test_Trading.py
@@ -418,6 +418,49 @@ async def test_set_balance_by_non_admin(trading_test_initializer):
 
 
 @pytest.mark.asyncio
+async def test_for_extremely_low_price_revert(trading_test_initializer):
+    starknet_service, python_executor, admin1, _, _, _, _, _, _, felix, gary, _, _, _, _, felix_test, gary_test, _, _, _, trading, marketPrices, _, holding, fee_balance, liquidity, insurance, trading_stats, _, _, _, _, _ = trading_test_initializer
+
+    ###################
+    ### Open orders ##
+    ###################
+    # List of users
+    users = [felix, gary]
+    users_test = [felix_test, gary_test]
+
+    # Sufficient balance for users
+    felix_balance = 10000
+    gary_balance = 10000
+    balance_array = [felix_balance, gary_balance]
+
+    # Batch params for OPEN orders
+    quantity_locked_1 = 10000
+    market_id_1 = BTC_USD_ID
+    asset_id_1 = AssetID.USDC
+    oracle_price_1 = 1950
+
+    # Set balance in Starknet & Python
+    await set_balance(admin_signer=admin1_signer, admin=admin1, users=users, users_test=users_test, balance_array=balance_array, asset_id=asset_id_1)
+
+    # Create orders
+    orders_1 = [{
+        "quantity": 10000,
+        "price": 1,
+        "order_type": order_types["limit"],
+        "leverage": 10
+    }, {
+        "quantity": 10000,
+        "price": 1,
+        "direction": order_direction["short"],
+        "order_type": order_types["limit"],
+        "leverage": 10
+    }]
+
+    # execute order
+    await execute_and_compare(zkx_node_signer=admin1_signer, zkx_node=admin1, executor=python_executor, orders=orders_1, users_test=users_test, quantity_locked=quantity_locked_1, market_id=market_id_1, oracle_price=oracle_price_1, trading=trading, is_reverted=1, error_code="531:", error_at_index=1, timestamp=timestamp, param_2=market_id_1)
+
+
+@pytest.mark.asyncio
 async def test_for_risk_while_opening_order(trading_test_initializer):
     starknet_service, python_executor, admin1, _, _, _, _, _, _, felix, gary, _, _, _, _, felix_test, gary_test, _, _, _, trading, marketPrices, _, holding, fee_balance, liquidity, insurance, trading_stats, _, _, _, _, _ = trading_test_initializer
 

--- a/L2/tests/test_Trading_0_fee.py
+++ b/L2/tests/test_Trading_0_fee.py
@@ -408,6 +408,49 @@ async def test_set_balance_by_non_admin(trading_test_initializer):
 
 
 @pytest.mark.asyncio
+async def test_for_extremely_low_price_revert(trading_test_initializer):
+    starknet_service, python_executor, admin1, _, _, _, _, _, _, felix, gary, _, _, _, _, felix_test, gary_test, _, _, _, trading, marketPrices, _, holding, fee_balance, liquidity, insurance, trading_stats, _, _, _, _, _ = trading_test_initializer
+
+    ###################
+    ### Open orders ##
+    ###################
+    # List of users
+    users = [felix, gary]
+    users_test = [felix_test, gary_test]
+
+    # Sufficient balance for users
+    felix_balance = 10000
+    gary_balance = 10000
+    balance_array = [felix_balance, gary_balance]
+
+    # Batch params for OPEN orders
+    quantity_locked_1 = 10000
+    market_id_1 = BTC_USD_ID
+    asset_id_1 = AssetID.USDC
+    oracle_price_1 = 1950
+
+    # Set balance in Starknet & Python
+    await set_balance(admin_signer=admin1_signer, admin=admin1, users=users, users_test=users_test, balance_array=balance_array, asset_id=asset_id_1)
+
+    # Create orders
+    orders_1 = [{
+        "quantity": 10000,
+        "price": 1,
+        "order_type": order_types["limit"],
+        "leverage": 10
+    }, {
+        "quantity": 10000,
+        "price": 1,
+        "direction": order_direction["short"],
+        "order_type": order_types["limit"],
+        "leverage": 10
+    }]
+
+    # execute order
+    await execute_and_compare(zkx_node_signer=admin1_signer, zkx_node=admin1, executor=python_executor, orders=orders_1, users_test=users_test, quantity_locked=quantity_locked_1, market_id=market_id_1, oracle_price=oracle_price_1, trading=trading, is_reverted=1, error_code="531:", error_at_index=1, timestamp=timestamp, param_2=market_id_1)
+
+
+@pytest.mark.asyncio
 async def test_for_risk_while_opening_order(trading_test_initializer):
     starknet_service, python_executor, admin1, _, _, _, _, _, _, felix, gary, _, _, _, _, felix_test, gary_test, _, _, _, trading, marketPrices, _, holding, fee_balance, liquidity, insurance, trading_stats, _, _, _, _, _ = trading_test_initializer
 


### PR DESCRIPTION
 - For short limit buy, check whether user has enough margin to open position and to cover unrealized gain of opposite order
 - For short limit sell, check whether user has enough balance to cover the losses if the position is underwater